### PR TITLE
Restore MG2 compatibility in onQueueComplete

### DIFF
--- a/ModelGlue/gesture/eventrequest/EventContext.cfc
+++ b/ModelGlue/gesture/eventrequest/EventContext.cfc
@@ -172,6 +172,7 @@
 			
 				<cfif isObject(getCurrentEventHandler()) and getCurrentEventHandler().name neq exceptionEventHandler and variables._modelGlue.hasEventHandler(exceptionEventHandler)>
 					<cfset addEventHandler(variables._modelGlue.getEventHandler(exceptionEventHandler)) />
+					<cfset addEventHandler(variables._modelGlue.getEventHandler("modelglue.onQueueComplete")) />
 					<cfset executeEventQueue() />
 				<cfelse>
 					<cfrethrow />


### PR DESCRIPTION
Aborting the current handler and short-circuiting to exception handler ignores onQueueComplete. This broke compatibility with MG2.  We should expect onQueueComplete to fire consistently whether it is after a standard event handler or an exception event handler.

A common use case would be to share presentation configuration information that is not required until all other processing is complete, e.g.:

```
<event-handler name="ModelGlue.onQueueComplete">
    <broadcasts>
        <message name="needSiteTheme" />
    </broadcasts>
</event-handler>
```

Why put it in onQueueComplete?  Consider that some other processing might determine which theme to display in a themeable system.
