### PR TITLE
Support missing events like 3.1.299 to fix #5

### DIFF
--- a/gesture/eventrequest/phase/Invocation.cfc
+++ b/gesture/eventrequest/phase/Invocation.cfc
@@ -85,6 +85,9 @@ then this file is a working copy and not part of a release build.
 		<cfset arguments.eventContext.addEventHandler(initialEventHandler) />
 	<cfelseif find("&", urlDecode(initialEventHandlerName) ) GT 0 AND unwindAndForward(urlDecode(initialEventHandlerName), arguments.eventContext) IS true>
 		<!--- unwindAndForward will never return true. It will redirect before it returns anything. If it can not redirect, then this branch will fail and the other branches will evaluate --->
+	<cfelseif structKeyExists(modelglue.eventHandlers, modelglue.configuration.missingEvent)>
+		<cfset arguments.eventContext.setValue("missingEvent", initialEventHandlerName) />
+		<cfset arguments.eventContext.addEventHandler(modelglue.eventHandlers[modelglue.configuration.missingEvent]) />
 	<cfelseif modelglue.hasEventHandler(modelglue.configuration.missingEvent)>
 		<cfset arguments.eventContext.setValue("missingEvent", initialEventHandlerName) />
 		<cfset arguments.eventContext.addEventHandler(modelglue.getEventHandler(modelglue.configuration.missingEvent)) />


### PR DESCRIPTION
The new code changes how missing events are handled and has led to a rash of situations where the "no known event handler" exception is thrown when I do in fact have a missing event handler.  

You can see the issue #5.
